### PR TITLE
[Documentation] Filters are disabled by default in Doctrine ^2.7 (#2165)

### DIFF
--- a/doc/symfony4.md
+++ b/doc/symfony4.md
@@ -138,7 +138,9 @@ doctrine:
         filters:
             softdeleteable:
                 class: Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter
-```     
+                enabled: true
+```  
+
 <a name="ext-listeners"></a>
 
 ## Doctrine extension listener services


### PR DESCRIPTION
* [Documentation] Filters are disabled by default in Doctrine ^2.7